### PR TITLE
Remove needs on release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@ on:
       - main
 jobs:
   release:
-    needs: test
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
## Changes
- Can't use needs if jobs aren't in the same workflow file