### PR TITLE
remove redpanda from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,38 +8,7 @@ services:
       - 5437:5432
     volumes: 
       - hub_orgs_db:/var/lib/postgresql/data
-  redpanda:
-    # NOTE: Use the latest version here!
-    image: docker.redpanda.com/vectorized/redpanda:latest
-    container_name: redpanda-1
-    command:
-    - redpanda
-    - start
-    - --smp
-    - '1'
-    - --reserve-memory
-    - 0M
-    - --overprovisioned
-    - --set redpanda.empty_seed_starts_cluster=false
-    - --set redpanda.auto_create_topics_enabled=true
-    - --seeds "redpanda-1:33145"
-    - --kafka-addr
-    - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
-    - --advertise-kafka-addr
-    - PLAINTEXT://redpanda:29092,OUTSIDE://localhost:9092
-    - --pandaproxy-addr
-    - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
-    - --advertise-pandaproxy-addr
-    - PLAINTEXT://redpanda:28082,OUTSIDE://localhost:8082
-    - --advertise-rpc-addr redpanda-1:33145
-    ports:
-    - 8081:8081
-    - 8082:8082
-    - 9092:9092
-    - 28082:28082
-    - 29092:29092
-
-
+      
   # ory hydra
   hydra:
     image: oryd/hydra:v2.0.3


### PR DESCRIPTION
 Only the core service should have redpanda in docker-compose because all services use the same redpanda instance.