### PR TITLE
Return active memberships for the user

### DIFF
--- a/api/src/entities/members.rs
+++ b/api/src/entities/members.rs
@@ -17,6 +17,7 @@ pub struct Model {
     #[sea_orm(nullable)]
     pub revoked_at: Option<DateTimeWithTimeZone>,
     pub invite_id: Uuid,
+    #[sea_orm(nullable)]
     pub deactivated_at: Option<DateTimeWithTimeZone>,
 }
 
@@ -110,5 +111,11 @@ impl ActiveModelBehavior for ActiveModel {}
 impl Entity {
     pub fn find_by_user(user: Uuid) -> Select<Self> {
         Self::find().filter(Column::UserId.eq(user).and(Column::RevokedAt.is_null()))
+    }
+
+    pub fn find_active_by_user(user: Uuid) -> Select<Self> {
+        Self::find()
+            .filter(Column::UserId.eq(user))
+            .filter(Column::DeactivatedAt.is_null())
     }
 }

--- a/api/src/handlers.rs
+++ b/api/src/handlers.rs
@@ -132,7 +132,7 @@ pub async fn browser_organization_select(
         .await
         .map_err(InternalServerError)?;
 
-    let memberships = members::Entity::find_by_user(user_id)
+    let memberships = members::Entity::find_active_by_user(user_id)
         .all(conn)
         .await
         .map_err(InternalServerError)?;

--- a/api/src/queries/user.rs
+++ b/api/src/queries/user.rs
@@ -79,7 +79,7 @@ impl User {
             .all(conn)
             .await?;
 
-        let org_members = members::Entity::find_by_user(user_id)
+        let org_members = members::Entity::find_active_by_user(user_id)
             .order_by_desc(members::Column::CreatedAt)
             .all(conn)
             .await?;


### PR DESCRIPTION
## Changes
- Adjust membership queries to filter out memberships that are deactivated
- Organization memberships still return deactivated user but they are noted as inactive